### PR TITLE
Add TrayManager for system tray functionality

### DIFF
--- a/src/main/app/Application.ts
+++ b/src/main/app/Application.ts
@@ -1,6 +1,8 @@
 import { registerIpcHandlers } from '../ipc/handlers';
 import { GraphQLService } from '../services/GraphQLService';
 import { GRAPHQL_HTTP_URL, GRAPHQL_WS_URL } from '../../shared/constants';
+import PomodoroService from '../services/PomodoroService';
+import TrayManager from './TrayManager';
 
 export default class Application {
   public async init(): Promise<void> {
@@ -15,6 +17,11 @@ export default class Application {
     const ok = await gql.testReconnect(2);
     // eslint-disable-next-line no-console
     console.log(`[GraphQL] health: ${ok}`);
+
+    // Initialize services used by Tray
+    const pomodoroService = new PomodoroService(gql);
+    const trayManager = new TrayManager(pomodoroService);
+    trayManager.init();
   }
 }
 

--- a/src/main/app/Application.ts
+++ b/src/main/app/Application.ts
@@ -5,6 +5,10 @@ import PomodoroService from '../services/PomodoroService';
 import TrayManager from './TrayManager';
 
 export default class Application {
+  private gql: GraphQLService | null = null;
+  private pomodoroService: PomodoroService | null = null;
+  private trayManager: TrayManager | null = null;
+
   public async init(): Promise<void> {
     // Minimal initialization (Tray, IPC, Services will be added later)
     // Startup log only for now
@@ -13,15 +17,21 @@ export default class Application {
     registerIpcHandlers();
 
     // Initialize GraphQL service and run a connection check
-    const gql = new GraphQLService({ httpUrl: GRAPHQL_HTTP_URL, wsUrl: GRAPHQL_WS_URL });
-    const ok = await gql.testReconnect(2);
+    this.gql = new GraphQLService({ httpUrl: GRAPHQL_HTTP_URL, wsUrl: GRAPHQL_WS_URL });
+    const ok = await this.gql.testReconnect(2);
     // eslint-disable-next-line no-console
     console.log(`[GraphQL] health: ${ok}`);
 
     // Initialize services used by Tray
-    const pomodoroService = new PomodoroService(gql);
-    const trayManager = new TrayManager(pomodoroService);
-    trayManager.init();
+    this.pomodoroService = new PomodoroService(this.gql);
+    this.trayManager = new TrayManager(this.pomodoroService);
+    this.trayManager.init();
+  }
+
+  public async destroy(): Promise<void> {
+    if (this.trayManager) {
+      this.trayManager.destroy();
+    }
   }
 }
 

--- a/src/main/app/Application.ts
+++ b/src/main/app/Application.ts
@@ -29,9 +29,7 @@ export default class Application {
   }
 
   public async destroy(): Promise<void> {
-    if (this.trayManager) {
-      this.trayManager.destroy();
-    }
+    this.trayManager?.destroy();
   }
 }
 

--- a/src/main/app/TrayManager.ts
+++ b/src/main/app/TrayManager.ts
@@ -62,13 +62,8 @@ export default class TrayManager {
   }
 
   public destroy(): void {
-    if (this.eventSubscription) {
-      this.eventSubscription();
-    }
-
-    if (this.tray) {
-      this.tray.destroy();
-    }
+    this.eventSubscription?.();
+    this.tray?.destroy();
   }
 
   private buildMenu(): Menu {

--- a/src/main/app/TrayManager.ts
+++ b/src/main/app/TrayManager.ts
@@ -4,13 +4,40 @@ import type { Pomodoro } from '../../shared/types/gomodoro';
 import type { PomodoroState } from '../../shared/types/gomodoro';
 import type { PomodoroPhase } from '../../shared/types/gomodoro';
 
+interface PomodoroConfig {
+  workDurationSec: number;
+  breakDurationSec: number;
+  longBreakDurationSec: number;
+  taskId: string;
+}
+
+const DEFAULT_POMODORO_CONFIG: PomodoroConfig = {
+  workDurationSec: 1500, // 25 minutes
+  breakDurationSec: 300,  // 5 minutes
+  longBreakDurationSec: 900, // 15 minutes
+  taskId: 'default-task',
+};
+
+const EMOJI_MAP = {
+  DEFAULT: '🍅',
+  PAUSED: '⏸️',
+  FINISHED: '✅',
+  WORK: '🎯',
+  SHORT_BREAK: '☕',
+  LONG_BREAK: '🌴',
+} as const;
+
 export default class TrayManager {
   private tray: Tray | null = null;
   private currentStateLabel: string = '';
   private currentState: PomodoroState | null = null;
   private currentPhase: PomodoroPhase | null = null;
+  private eventSubscription: (() => void) | null = null;
 
-  constructor(private readonly pomodoroService: PomodoroService) {}
+  constructor(
+    private readonly pomodoroService: PomodoroService,
+    private readonly config: PomodoroConfig = DEFAULT_POMODORO_CONFIG
+  ) {}
 
   public init(): void {
     this.tray = new Tray(nativeImage.createEmpty());
@@ -19,15 +46,29 @@ export default class TrayManager {
     this.setTrayTooltip();
     this.setTrayTitle('');
 
-    this.pomodoroService.subscribePomodoroEvents((p) => {
+    this.eventSubscription = this.pomodoroService.subscribePomodoroEvents((p) => {
       this.applyPomodoro(p);
       this.refreshMenu();
     });
 
-    this.pomodoroService.getCurrentPomodoro().then((p) => {
-      this.applyPomodoro(p);
-      this.refreshMenu();
-    });
+    this.pomodoroService.getCurrentPomodoro()
+      .then((p) => {
+        this.applyPomodoro(p);
+        this.refreshMenu();
+      })
+      .catch((error) => {
+        console.error('[TrayManager] Failed to get current pomodoro:', error);
+      });
+  }
+
+  public destroy(): void {
+    if (this.eventSubscription) {
+      this.eventSubscription();
+    }
+
+    if (this.tray) {
+      this.tray.destroy();
+    }
   }
 
   private buildMenu(): Menu {
@@ -51,31 +92,36 @@ export default class TrayManager {
       actionItems.push({
         label: 'Start',
         click: async () => {
-          await this.pomodoroService.startPomodoro({
-            workDurationSec: 1500,
-            breakDurationSec: 300,
-            longBreakDurationSec: 900,
-            taskId: 'default-task',
-          });
+          try {
+            await this.pomodoroService.startPomodoro(this.config);
+          } catch (error) {
+            console.error('[TrayManager] Failed to start pomodoro:', error);
+          }
         },
       });
     }
     if (canPause) {
       actionItems.push({
         label: 'Pause',
-        click: () => this.pomodoroService.pausePomodoro().catch(() => {}),
+        click: () => this.pomodoroService.pausePomodoro().catch((error) => {
+          console.error('[TrayManager] Failed to pause pomodoro:', error);
+        }),
       });
     }
     if (canResume) {
       actionItems.push({
         label: 'Resume',
-        click: () => this.pomodoroService.resumePomodoro().catch(() => {}),
+        click: () => this.pomodoroService.resumePomodoro().catch((error) => {
+          console.error('[TrayManager] Failed to resume pomodoro:', error);
+        }),
       });
     }
     if (canStop) {
       actionItems.push({
         label: 'Stop',
-        click: () => this.pomodoroService.stopPomodoro().catch(() => {}),
+        click: () => this.pomodoroService.stopPomodoro().catch((error) => {
+          console.error('[TrayManager] Failed to stop pomodoro:', error);
+        }),
       });
     }
 
@@ -102,10 +148,13 @@ export default class TrayManager {
   }
 
   private toggleMainWindow(): void {
-    const win = BrowserWindow.getAllWindows()[0];
-    if (!win) {
+    const windows = BrowserWindow.getAllWindows();
+    if (windows.length === 0) {
+      console.warn('[TrayManager] No windows available to toggle');
       return;
     }
+    
+    const win = windows[0];
     if (win.isFocused()) {
       win.hide();
     } else {
@@ -116,7 +165,7 @@ export default class TrayManager {
 
   private setTrayTitle(text: string): void {
     if (!this.tray) return;
-    const emoji = this.emojiFor(this.currentState, this.currentPhase ?? undefined);
+    const emoji = this.emojiFor(this.currentState, this.currentPhase);
     const title = text ? `${emoji} ${text}` : `${emoji}`;
     this.tray.setTitle(title);
   }
@@ -143,19 +192,20 @@ export default class TrayManager {
     this.setTrayTooltip();
   }
 
-  private emojiFor(state: PomodoroState | null, phase?: PomodoroPhase): string {
-    if (state === null) return '🍅';
-    if (state === 'PAUSED') return '⏸️';
-    if (state === 'FINISHED') return '✅';
+  private emojiFor(state: PomodoroState | null, phase: PomodoroPhase | null): string {
+    if (state === null) return EMOJI_MAP.DEFAULT;
+    if (state === 'PAUSED') return EMOJI_MAP.PAUSED;
+    if (state === 'FINISHED') return EMOJI_MAP.FINISHED;
+    
     switch (phase) {
       case 'WORK':
-        return '🎯';
+        return EMOJI_MAP.WORK;
       case 'SHORT_BREAK':
-        return '☕';
+        return EMOJI_MAP.SHORT_BREAK;
       case 'LONG_BREAK':
-        return '🌴';
+        return EMOJI_MAP.LONG_BREAK;
       default:
-        return '🍅';
+        return EMOJI_MAP.DEFAULT;
     }
   }
 

--- a/src/main/app/TrayManager.ts
+++ b/src/main/app/TrayManager.ts
@@ -1,0 +1,169 @@
+import { app, BrowserWindow, Menu, MenuItemConstructorOptions, Tray, nativeImage } from 'electron';
+import PomodoroService from '../services/PomodoroService';
+import type { Pomodoro } from '../../shared/types/gomodoro';
+import type { PomodoroState } from '../../shared/types/gomodoro';
+import type { PomodoroPhase } from '../../shared/types/gomodoro';
+
+export default class TrayManager {
+  private tray: Tray | null = null;
+  private currentStateLabel: string = '';
+  private currentState: PomodoroState | null = null;
+  private currentPhase: PomodoroPhase | null = null;
+
+  constructor(private readonly pomodoroService: PomodoroService) {}
+
+  public init(): void {
+    this.tray = new Tray(nativeImage.createEmpty());
+    this.tray.setContextMenu(this.buildMenu());
+
+    this.setTrayTooltip();
+    this.setTrayTitle('');
+
+    this.pomodoroService.subscribePomodoroEvents((p) => {
+      this.applyPomodoro(p);
+      this.refreshMenu();
+    });
+
+    this.pomodoroService.getCurrentPomodoro().then((p) => {
+      this.applyPomodoro(p);
+      this.refreshMenu();
+    });
+  }
+
+  private buildMenu(): Menu {
+    const isActive = this.currentState === 'ACTIVE';
+    const isPaused = this.currentState === 'PAUSED';
+
+    const canStart = !isActive && !isPaused;
+    const canPause = isActive;
+    const canResume = isPaused;
+    const canStop = isActive || isPaused;
+
+    const template: MenuItemConstructorOptions[] = [
+      {
+        label: 'Show / Hide',
+        click: () => this.toggleMainWindow(),
+      },
+    ];
+
+    const actionItems: MenuItemConstructorOptions[] = [];
+    if (canStart) {
+      actionItems.push({
+        label: 'Start',
+        click: async () => {
+          await this.pomodoroService.startPomodoro({
+            workDurationSec: 1500,
+            breakDurationSec: 300,
+            longBreakDurationSec: 900,
+            taskId: 'default-task',
+          });
+        },
+      });
+    }
+    if (canPause) {
+      actionItems.push({
+        label: 'Pause',
+        click: () => this.pomodoroService.pausePomodoro().catch(() => {}),
+      });
+    }
+    if (canResume) {
+      actionItems.push({
+        label: 'Resume',
+        click: () => this.pomodoroService.resumePomodoro().catch(() => {}),
+      });
+    }
+    if (canStop) {
+      actionItems.push({
+        label: 'Stop',
+        click: () => this.pomodoroService.stopPomodoro().catch(() => {}),
+      });
+    }
+
+    if (actionItems.length > 0) {
+      template.push({ type: 'separator' }, ...actionItems);
+    }
+
+    template.push(
+      { type: 'separator' },
+      {
+        label: 'Quit',
+        role: 'quit',
+        accelerator: 'Cmd+Q',
+        click: () => app.quit(),
+      },
+    );
+
+    return Menu.buildFromTemplate(template);
+  }
+
+  private refreshMenu(): void {
+    if (!this.tray) return;
+    this.tray.setContextMenu(this.buildMenu());
+  }
+
+  private toggleMainWindow(): void {
+    const win = BrowserWindow.getAllWindows()[0];
+    if (!win) {
+      return;
+    }
+    if (win.isFocused()) {
+      win.hide();
+    } else {
+      win.show();
+      win.focus();
+    }
+  }
+
+  private setTrayTitle(text: string): void {
+    if (!this.tray) return;
+    const emoji = this.emojiFor(this.currentState, this.currentPhase ?? undefined);
+    const title = text ? `${emoji} ${text}` : `${emoji}`;
+    this.tray.setTitle(title);
+  }
+
+  private setTrayTooltip(): void {
+    if (!this.tray) return;
+    const tooltip = this.currentStateLabel ? `Gomodoro • ${this.currentStateLabel}` : 'Gomodoro';
+    this.tray.setToolTip(tooltip);
+  }
+
+  private applyPomodoro(pomodoro: Pomodoro | null): void {
+    if (pomodoro) {
+      const mm = this.formatTime(pomodoro.remainingTimeSec);
+      this.currentStateLabel = `${pomodoro.phase} #${pomodoro.phaseCount} ${mm}`;
+      this.currentState = pomodoro.state;
+      this.currentPhase = pomodoro.phase;
+      this.setTrayTitle(mm);
+    } else {
+      this.currentState = null;
+      this.currentStateLabel = '';
+      this.currentPhase = null;
+      this.setTrayTitle('');
+    }
+    this.setTrayTooltip();
+  }
+
+  private emojiFor(state: PomodoroState | null, phase?: PomodoroPhase): string {
+    if (state === null) return '🍅';
+    if (state === 'PAUSED') return '⏸️';
+    if (state === 'FINISHED') return '✅';
+    switch (phase) {
+      case 'WORK':
+        return '🎯';
+      case 'SHORT_BREAK':
+        return '☕';
+      case 'LONG_BREAK':
+        return '🌴';
+      default:
+        return '🍅';
+    }
+  }
+
+  private formatTime(totalSeconds: number): string {
+    const minutes = Math.floor(totalSeconds / 60);
+    const seconds = totalSeconds % 60;
+    return `${minutes}:${seconds.toString().padStart(2, '0')}`;
+  }
+}
+
+

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -2,6 +2,8 @@ import { app, BrowserWindow } from 'electron';
 import path from 'node:path';
 import Application from './app/Application';
 
+let application: Application | null = null;
+
 const createWindow = () => {
   const mainWindow = new BrowserWindow({
     width: 800,
@@ -36,7 +38,7 @@ if (!gotLock) {
 
   app.on('ready', async () => {
     app.dock?.hide();
-    const application = new Application();
+    application = new Application();
     await application.init();
     createWindow();
   });
@@ -45,6 +47,13 @@ if (!gotLock) {
 app.on('activate', () => {
   if (BrowserWindow.getAllWindows().length === 0) {
     createWindow();
+  }
+});
+
+app.on('before-quit', async () => {
+  if (application) {
+    await application.destroy();
+    application = null;
   }
 });
 

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -51,10 +51,7 @@ app.on('activate', () => {
 });
 
 app.on('before-quit', async () => {
-  if (application) {
-    await application.destroy();
-    application = null;
-  }
+  await application?.destroy();
 });
 
 


### PR DESCRIPTION
## WHAT
- Implemented TrayManager class to handle system tray operations with context menu
- Added Start/Pause/Resume/Stop actions accessible from the system tray
- Integrated pomodoro timer status display in tray title with relevant emojis
- Added ability to toggle main window visibility from tray menu
- Connected TrayManager to Application initialization flow

## WHY
This enhancement provides users with quick access to pomodoro controls without needing to keep the main application window open. The system tray integration allows for better workflow integration and provides at-a-glance status of the current pomodoro session.

🤖 Generated with [Claude Code](https://claude.ai/code)