### PR TITLE
Add NotificationService for Pomodoro completion alerts

### DIFF
--- a/src/main/app/Application.ts
+++ b/src/main/app/Application.ts
@@ -3,6 +3,7 @@ import { GraphQLService } from '../services/GraphQLService';
 import { GRAPHQL_HTTP_URL, GRAPHQL_WS_URL } from '../../shared/constants';
 import PomodoroService from '../services/PomodoroService';
 import TrayManager from './TrayManager';
+import NotificationService from '../services/NotificationService';
 
 export default class Application {
   private gql: GraphQLService | null = null;
@@ -24,7 +25,8 @@ export default class Application {
 
     // Initialize services used by Tray
     this.pomodoroService = new PomodoroService(this.gql);
-    this.trayManager = new TrayManager(this.pomodoroService);
+    const notificationService = new NotificationService();
+    this.trayManager = new TrayManager(this.pomodoroService, undefined, notificationService);
     this.trayManager.init();
   }
 

--- a/src/main/services/NotificationService.ts
+++ b/src/main/services/NotificationService.ts
@@ -1,0 +1,51 @@
+import { app, BrowserWindow, Notification } from 'electron';
+import type { PomodoroPhase, PomodoroState } from '../../shared/types/gomodoro';
+
+export default class NotificationService {
+  public notifyFinished(state: PomodoroState, phase: PomodoroPhase): void {
+    if (state !== 'FINISHED') return;
+
+    const title = 'Gomodoro';
+    const body = this.buildFinishedBody(phase);
+    this.show(title, body);
+  }
+
+  private buildFinishedBody(phase: PomodoroPhase): string {
+    const phaseLabel = (() => {
+      switch (phase) {
+        case 'WORK':
+          return 'Work';
+        case 'SHORT_BREAK':
+          return 'Short break';
+        case 'LONG_BREAK':
+          return 'Long break';
+        default:
+          return String(phase);
+      }
+    })();
+
+    return `${phaseLabel} finished!`;
+  }
+
+  private show(title: string, body: string): void {
+    if (!Notification.isSupported()) return;
+
+    const notification = new Notification({ title, body, silent: false });
+    notification.on('click', () => {
+      const win = BrowserWindow.getAllWindows()[0];
+      if (!win) return;
+
+      try {
+        if (win.isMinimized()) win.restore();
+        win.show();
+        app.focus();
+        win.focus();
+      } catch {
+        console.error('Failed to show notification');
+      }
+    });
+    notification.show();
+  }
+}
+
+


### PR DESCRIPTION
## WHAT
Added a new NotificationService that shows system notifications when Pomodoro sessions finish. The service integrates with the existing TrayManager to display native notifications for completed work phases and break phases.

Key changes:
- Created `src/main/services/NotificationService.ts` with notification display logic
- Modified `TrayManager.ts` to detect state transitions and trigger notifications 
- Updated `Application.ts` to instantiate and inject the NotificationService
- Added click-to-focus functionality to bring the app window to front when notification is clicked

## WHY
Users need visual feedback when Pomodoro sessions complete, especially when the application is running in the background. This enhances the user experience by providing clear alerts for session transitions without requiring users to constantly monitor the tray icon.

🤖 Generated with [Claude Code](https://claude.ai/code)