### PR TITLE
Improve release workflow with parallel builds and version reset

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,9 +20,11 @@ permissions:
   id-token: write
 
 jobs:
-  release:
-    name: Release
+  version:
+    name: Version Bump
     runs-on: ubuntu-latest
+    outputs:
+      new_version: ${{ steps.version.outputs.new_version }}
     steps:
       - uses: actions/checkout@v4
       
@@ -47,19 +49,89 @@ jobs:
         run: |
           npm version ${{ github.event.inputs.version_type }}
           echo "new_version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
+
+      - name: Upload version artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: version-update
+          path: |
+            package.json
+            package-lock.json
+
+  build-darwin:
+    name: Build for macOS
+    needs: version
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        arch: [x64, arm64]
+    steps:
+      - uses: actions/checkout@v4
       
-      - name: Build for x64
-        run: npm run make -- --platform=darwin --arch=x64
+      - name: Download version artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: version-update
       
-      - name: Build for arm64
-        run: npm run make -- --platform=darwin --arch=arm64
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: 'package.json'
+          cache: 'npm'
+      
+      - name: Install dependencies
+        run: npm ci
+      
+      - name: Build for ${{ matrix.arch }}
+        run: npm run make -- --platform=darwin --arch=${{ matrix.arch }}
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-darwin-${{ matrix.arch }}
+          path: out/make/**/*
+
+  release:
+    name: Create Release
+    needs: [version, build-darwin]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Download version artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: version-update
+
+      - name: Download all build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: build-*
+          path: out/make/
+          merge-multiple: true
+      
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: 'package.json'
+          cache: 'npm'
+      
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Setup Git
+        run: |
+          git config --global user.name "${GITHUB_USER}"
+          git config --global user.email "${GITHUB_USER}@users.noreply.github.com"
+        env:
+          GITHUB_USER: github-actions[bot]
       
       - name: Push tags
         run: git push --tags
       
       - name: Create GitHub Release
         run: |
-          gh release create v${{ steps.version.outputs.new_version }} --generate-notes
+          gh release create v${{ needs.version.outputs.new_version }} --generate-notes
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gomodoro-desktop",
   "productName": "gomodoro-desktop",
-  "version": "1.0.0",
+  "version": "0.0.1",
   "description": "My Electron application description",
   "main": ".vite/build/main.js",
   "volta": {


### PR DESCRIPTION
## Summary
- Split release workflow into version bump, parallel Darwin builds, and release creation jobs
- Add artifact upload/download for coordination between jobs  
- Reset version from 1.0.0 to 0.0.1 for proper semantic versioning
- Add matrix strategy for x64/arm64 builds to improve CI/CD efficiency

## Changes
- **Release Workflow**: Restructured `.github/workflows/release.yml` with separate jobs for version bumping, building, and releasing
- **Version Reset**: Updated `package.json` version from 1.0.0 to 0.0.1 for proper semantic versioning start
- **Parallel Builds**: Added matrix strategy for Darwin x64/arm64 builds to reduce overall workflow time
- **Artifact Management**: Implemented proper artifact upload/download between workflow jobs

## Test Plan
- [ ] Verify workflow syntax is valid
- [ ] Test manual dispatch trigger works correctly
- [ ] Confirm parallel builds complete successfully
- [ ] Validate artifact coordination between jobs
- [ ] Ensure release creation works with new structure

🤖 Generated with [Claude Code](https://claude.ai/code)