### PR TITLE
Update release workflow to use publish dry-run and fix tag pushing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,7 @@ jobs:
         run: npm ci
       
       - name: Build for ${{ matrix.arch }}
-        run: npm run make -- --platform=darwin --arch=${{ matrix.arch }}
+        run: npm run publish -- --dry-run --platform=darwin --arch=${{ matrix.arch }}
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
@@ -127,7 +127,7 @@ jobs:
           GITHUB_USER: github-actions[bot]
       
       - name: Push tags
-        run: git push --tags
+        run: git push origin main --tags
       
       - name: Create GitHub Release
         run: |
@@ -136,6 +136,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       
       - name: Publish to GitHub Releases
-        run: npm run publish
+        run: npm run publish -- --from-dry-run
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## WHAT
Updated the GitHub Actions release workflow to improve the build and publish process.

Changes made:
- Changed build command from `npm run make` to `npm run publish -- --dry-run` for better artifact handling
- Fixed git push command to explicitly push to `origin main --tags` instead of just `--tags`
- Updated final publish step to use `--from-dry-run` flag for proper release flow

## WHY
These changes improve the reliability and consistency of the release process:
- Using `--dry-run` first ensures artifacts are properly prepared before actual publishing
- Explicit branch specification in git push prevents potential issues with detached HEAD states
- The `--from-dry-run` flag allows reusing previously built artifacts for the final publish step

🤖 Generated with [Claude Code](https://claude.ai/code)