### PR TITLE
Fix GitHub Actions release workflow artifact paths

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,6 +72,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: version-update
+          path: |
+            package.json
+            package-lock.json
       
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -89,7 +92,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: build-darwin-${{ matrix.arch }}
-          path: out/make/**/*
+          path: out/**/*
 
   release:
     name: Create Release
@@ -102,12 +105,15 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: version-update
+          path: |
+            package.json
+            package-lock.json
 
       - name: Download all build artifacts
         uses: actions/download-artifact@v4
         with:
           pattern: build-*
-          path: out/make/
+          path: out
           merge-multiple: true
       
       - name: Setup Node.js


### PR DESCRIPTION
## WHAT
- Added explicit path specification for version-update artifact downloads in the release workflow
- Updated build artifact path from `out/make/**/*` to `out/**/*` for better artifact collection
- Improved artifact download configuration with explicit path mappings

## WHY
These changes were necessary to fix issues with GitHub Actions artifact handling in the release workflow:
- The version-update artifact download was missing explicit path configuration, which could cause inconsistent behavior
- The build artifact path was too specific (`out/make/**/*`) and needed to be broadened to `out/**/*` to capture all build outputs properly
- Better artifact path specification improves the reliability of the automated release process

🤖 Generated with [Claude Code](https://claude.ai/code)