### PR TITLE
Disable changelog generation in tagpr configuration

### DIFF
--- a/.tagpr
+++ b/.tagpr
@@ -2,3 +2,4 @@
 	vPrefix = true
 	releaseBranch = main
 	versionFile = package.json
+    changelog = false


### PR DESCRIPTION
## Summary

This PR disables automatic changelog generation in the tagpr configuration by adding  to the  file.

## Changes
- Added  to  configuration file

## Motivation
This change prevents tagpr from automatically generating changelogs, giving more control over changelog management.

## Test plan
- Verify the tagpr configuration is valid
- Test that tagpr operations work as expected without changelog generation