### PR TITLE
Configure tagpr to create draft releases

### DIFF
--- a/.tagpr
+++ b/.tagpr
@@ -3,3 +3,5 @@
 	releaseBranch = main
 	versionFile = package.json
     changelog = false
+    # Since default GITHUB_TOKEN will not trigger the published event, manually release it.
+    release = draft


### PR DESCRIPTION
## WHAT
- Added `release = draft` configuration to the `.tagpr` file
- Included a comment explaining the rationale for this change

## WHY
The default GITHUB_TOKEN does not trigger the `published` event when creating releases. By configuring tagpr to create draft releases, we ensure that releases need to be manually published, which provides better control over the release process and ensures proper event triggering for downstream automation.

This change improves the release workflow by:
- Preventing automatic publishing of potentially incomplete releases
- Allowing for manual review before releases are made public
- Ensuring proper GitHub event handling for release automation