### PR TITLE
Add task name display to timer component

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -100,7 +100,7 @@ export default function App(): React.ReactElement {
 
             <Fade in={!showTaskManager} timeout={300} unmountOnExit>
               <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 2 }}>
-                <Timer pomodoro={pomodoro} />
+                <Timer pomodoro={pomodoro} tasks={tasks} />
                 
                 <Controls
                   isLoading={isLoading}

--- a/src/renderer/components/Timer/Timer.tsx
+++ b/src/renderer/components/Timer/Timer.tsx
@@ -11,7 +11,7 @@ import {
   Work as WorkIcon,
   Coffee as BreakIcon,
 } from '@mui/icons-material';
-import type { Pomodoro, PomodoroPhase } from '../../../shared/types/gomodoro';
+import type { Pomodoro, PomodoroPhase, Task } from '../../../shared/types/gomodoro';
 
 type PhaseConfig = {
   icon: React.ReactElement;
@@ -21,6 +21,7 @@ type PhaseConfig = {
 
 type Props = {
   pomodoro: Pomodoro | null;
+  tasks: Task[];
 };
 
 const PHASE_CONFIG: Record<PomodoroPhase, PhaseConfig> = {
@@ -59,7 +60,7 @@ const getPhaseConfig = (phase: string): PhaseConfig => {
   };
 };
 
-export default function Timer({ pomodoro }: Props): React.ReactElement {
+export default function Timer({ pomodoro, tasks }: Props): React.ReactElement {
   if (!pomodoro) {
     return (
       <Box 
@@ -79,6 +80,7 @@ export default function Timer({ pomodoro }: Props): React.ReactElement {
   }
 
   const phaseConfig = getPhaseConfig(pomodoro.phase);
+  const currentTask = tasks.find(task => task.id === pomodoro.taskId);
   
   return (
     <Box>
@@ -132,6 +134,19 @@ export default function Timer({ pomodoro }: Props): React.ReactElement {
               </Typography>
             </Box>
           </Box>
+
+          {/* Task name */}
+          {currentTask && (
+            <Typography 
+              variant="h6" 
+              color="text.primary"
+              sx={{
+                fontSize: 'clamp(1rem, 3vw, 1.5rem)',
+              }}
+            >
+              {currentTask.title}
+            </Typography>
+          )}
 
           {/* Status indicator */}
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>


### PR DESCRIPTION
## WHAT
<\!-- Describe what changes you made -->
Added task name display functionality to the timer component. The current task name is now shown below the circular progress timer, positioned between the timer and status indicator.

Changes include:
- Modified Timer component to accept tasks prop
- Added logic to find and display current task based on pomodoro.taskId
- Implemented responsive font sizing for optimal visibility
- Positioned task name for clean visual hierarchy

## WHY
<\!-- Explain why these changes were necessary -->
Users needed better visibility of what task they are currently working on during pomodoro sessions. Previously, the timer only showed the phase (Work, Break) and remaining time, but not the specific task being worked on. This improvement provides immediate context about the current work focus without cluttering the interface.

The task name placement went through several iterations to find the optimal position:
1. Initially placed above the phase indicator (too prominent)
2. Tried inside the circular progress (caused overlap issues with long names)
3. Finally positioned below the timer (maintains hierarchy while ensuring readability)

🤖 Generated with [Claude Code](https://claude.ai/code)