### PR TITLE
Add macOS code signing and notarization support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,10 @@ jobs:
       - name: Add macOS certificate
         run: |
           ./scripts/add-macos-cert.sh
+        env:
+          # For Code Signing
+          MACOS_CERT_P12_BASE64: ${{ secrets.MACOS_CERT_P12_BASE64 }}
+          MACOS_CERT_PASSWORD: ${{ secrets.MACOS_CERT_PASSWORD }}
 
       - name: Generate App Store Connect API key file
         run: |
@@ -40,9 +44,6 @@ jobs:
       - name: Build for ${{ matrix.arch }}
         run: npm run publish -- --dry-run --platform=darwin --arch=${{ matrix.arch }}
         env:
-          # For Code Signing
-          MACOS_CERT_P12_BASE64: ${{ secrets.MACOS_CERT_P12_BASE64 }}
-          MACOS_CERT_PASSWORD: ${{ secrets.MACOS_CERT_PASSWORD }}
           # For Notarization
           APPLE_API_KEY: appstore-connect-api-key.p8
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,9 +28,25 @@ jobs:
       
       - name: Install dependencies
         run: npm ci
+
+      - name: Add macOS certificate
+        run: |
+          ./scripts/add-macos-cert.sh
+
+      - name: Generate App Store Connect API key file
+        run: |
+          echo "${{ secrets.APPLE_API_KEY_BASE64 }}" | base64 -d > appstore-connect-api-key.p8
       
       - name: Build for ${{ matrix.arch }}
         run: npm run publish -- --dry-run --platform=darwin --arch=${{ matrix.arch }}
+        env:
+          # For Code Signing
+          MACOS_CERT_P12_BASE64: ${{ secrets.MACOS_CERT_P12_BASE64 }}
+          MACOS_CERT_PASSWORD: ${{ secrets.MACOS_CERT_PASSWORD }}
+          # For Notarization
+          APPLE_API_KEY: appstore-connect-api-key.p8
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -7,6 +7,12 @@ import { FuseV1Options, FuseVersion } from '@electron/fuses';
 const config: ForgeConfig = {
   packagerConfig: {
     asar: true,
+    osxSign: {},
+    osxNotarize: {
+      appleApiKey: process.env.APPLE_API_KEY!,
+      appleApiKeyId: process.env.APPLE_API_KEY_ID!,
+      appleApiIssuer: process.env.APPLE_API_ISSUER!
+    }
   },
   rebuildConfig: {},
   makers: [new MakerZIP({}, ['darwin'])],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gomodoro-desktop",
-  "version": "0.0.4",
+  "version": "0.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gomodoro-desktop",
-      "version": "0.0.4",
+      "version": "0.0.7",
       "license": "MIT",
       "dependencies": {
         "@apollo/client": "^3.10.8",
@@ -14,6 +14,7 @@
         "@emotion/styled": "^11.14.1",
         "@mui/icons-material": "^5.18.0",
         "@mui/material": "^5.16.7",
+        "electron-log": "^5.4.3",
         "graphql-ws": "^5.14.3",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -6981,6 +6982,15 @@
       },
       "engines": {
         "node": ">= 12.20.55"
+      }
+    },
+    "node_modules/electron-log": {
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/electron-log/-/electron-log-5.4.3.tgz",
+      "integrity": "sha512-sOUsM3LjZdugatazSQ/XTyNcw8dfvH1SYhXWiJyfYodAAKOZdHs0txPiLDXFzOZbhXgAgshQkshH2ccq0feyLQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/electron-to-chromium": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@emotion/styled": "^11.14.1",
     "@mui/icons-material": "^5.18.0",
     "@mui/material": "^5.16.7",
+    "electron-log": "^5.4.3",
     "graphql-ws": "^5.14.3",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/scripts/add-macos-cert.sh
+++ b/scripts/add-macos-cert.sh
@@ -1,0 +1,26 @@
+#! /bin/bash
+
+set -eo pipefail
+
+${MACOS_CERT_P12_BASE64:?MACOS_CERT_P12_BASE64 is not set}
+${MACOS_CERT_PASSWORD:?MACOS_CERT_PASSWORD is not set}
+
+MACOS_CERT_P12_FILE=certificate.p12
+echo -n "$MACOS_CERT_P12_BASE64" | base64 -d > "$MACOS_CERT_P12_FILE"
+
+KEY_CHAIN=build.keychain
+
+security create-keychain -p actions $KEY_CHAIN
+# Make the keychain the default so identities are found
+security default-keychain -s $KEY_CHAIN
+# Unlock the keychain
+security unlock-keychain -p actions $KEY_CHAIN
+# Import the certificate
+security import $MACOS_CERT_P12_FILE -k $KEY_CHAIN -P "$MACOS_CERT_PASSWORD" -T /usr/bin/codesign;
+# Set the partition list
+security set-key-partition-list -S apple-tool:,apple: -s -k actions $KEY_CHAIN
+
+# Debugging to show the certificate
+security find-identity
+# Remove certs
+rm -fr *.p12

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -2,6 +2,9 @@ import { app, BrowserWindow } from 'electron';
 import path from 'node:path';
 import Application from './app/Application';
 import { updateElectronApp } from 'update-electron-app'
+import log from 'electron-log'
+
+log.initialize();
 
 let application: Application | null = null;
 


### PR DESCRIPTION
## WHAT
- Added certificate installation script (`scripts/add-macos-cert.sh`) for GitHub Actions CI
- Configured `osxSign` and `osxNotarize` options in Electron Forge configuration
- Updated release workflow with environment variables for code signing and notarization
- Added electron-log dependency and initialized logging in main process
- Bumped version to 0.0.7

## WHY
This enables proper macOS app distribution by implementing code signing and notarization, which are required for macOS apps to run without security warnings and be distributed outside the App Store. The changes ensure the CI pipeline can automatically sign and notarize builds using Apple Developer certificates and API keys stored as GitHub secrets.

🤖 Generated with [Claude Code](https://claude.ai/code)