### PR TITLE
Remove debugging output from macOS certificate installation script

### DIFF
--- a/scripts/add-macos-cert.sh
+++ b/scripts/add-macos-cert.sh
@@ -19,8 +19,5 @@ security unlock-keychain -p actions $KEY_CHAIN
 security import $MACOS_CERT_P12_FILE -k $KEY_CHAIN -P "$MACOS_CERT_PASSWORD" -T /usr/bin/codesign;
 # Set the partition list
 security set-key-partition-list -S apple-tool:,apple: -s -k actions $KEY_CHAIN
-
-# Debugging to show the certificate
-security find-identity
 # Remove certs
 rm -fr *.p12


### PR DESCRIPTION
## WHAT
Remove debugging output from the macOS certificate installation script by removing the `security find-identity` command that was used for debugging purposes.

## WHY
The debugging output is no longer needed in the production script and removing it cleans up the build process output.

🤖 Generated with [Claude Code](https://claude.ai/code)