### PR TITLE
Suppress verbose output from certificate import

### DIFF
--- a/scripts/add-macos-cert.sh
+++ b/scripts/add-macos-cert.sh
@@ -13,7 +13,7 @@ security default-keychain -s $KEY_CHAIN
 # Unlock the keychain
 security unlock-keychain -p actions $KEY_CHAIN
 # Import the certificate
-security import $MACOS_CERT_P12_FILE -k $KEY_CHAIN -P "$MACOS_CERT_PASSWORD" -T /usr/bin/codesign;
+security import $MACOS_CERT_P12_FILE -k $KEY_CHAIN -P "$MACOS_CERT_PASSWORD" -T /usr/bin/codesign > /dev/null;
 # Set the partition list
 security set-key-partition-list -S apple-tool:,apple: -s -k actions $KEY_CHAIN
 # Remove certs


### PR DESCRIPTION
## WHAT
- Added output redirection (`> /dev/null`) to the `security import` command in the macOS certificate script
- Prevents verbose certificate metadata from appearing in CI/build logs

## WHY
The `security import` command outputs detailed certificate information including fingerprints, UUIDs, and other metadata that, while not directly sensitive, should not be exposed in public logs for security best practices. This change suppresses the verbose output while maintaining error reporting capabilities through stderr.

🤖 Generated with [Claude Code](https://claude.ai/code)