### PR TITLE
Make osxNotarize config conditional on environment variables

### DIFF
--- a/forge.config.ts
+++ b/forge.config.ts
@@ -8,11 +8,13 @@ const config: ForgeConfig = {
   packagerConfig: {
     asar: true,
     osxSign: {},
-    osxNotarize: {
-      appleApiKey: process.env.APPLE_API_KEY!,
-      appleApiKeyId: process.env.APPLE_API_KEY_ID!,
-      appleApiIssuer: process.env.APPLE_API_ISSUER!
-    }
+    ...(process.env.APPLE_API_KEY && process.env.APPLE_API_KEY_ID && process.env.APPLE_API_ISSUER && {
+      osxNotarize: {
+        appleApiKey: process.env.APPLE_API_KEY,
+        appleApiKeyId: process.env.APPLE_API_KEY_ID,
+        appleApiIssuer: process.env.APPLE_API_ISSUER
+      }
+    })
   },
   rebuildConfig: {},
   makers: [new MakerZIP({}, ['darwin'])],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gomodoro-desktop",
-  "productName": "gomodoro-desktop",
+  "productName": "Gomodoro",
   "version": "0.0.11",
   "description": "My Electron application description",
   "main": ".vite/build/main.js",


### PR DESCRIPTION
## WHAT
Modified the Electron Forge configuration to make the `osxNotarize` settings conditional on the presence of required Apple API environment variables.

## WHY
Previously, the `osxNotarize` configuration was always included even when the Apple API environment variables (`APPLE_API_KEY`, `APPLE_API_KEY_ID`, `APPLE_API_ISSUER`) were not set. This could cause build failures or unexpected behavior when building without proper Apple Developer credentials.

This change ensures that:
- The `osxNotarize` configuration is only applied when all required environment variables are present
- Builds can succeed even without Apple API credentials (useful for development or CI environments that don't need notarization)
- The configuration remains fully functional when all credentials are properly set

The implementation uses object spread syntax with conditional logic to include the `osxNotarize` object only when all three required environment variables are defined.