### PR TITLE
Configure electron updater with explicit repository and logging

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1,7 +1,7 @@
 import { app, BrowserWindow } from 'electron';
 import path from 'node:path';
 import Application from './app/Application';
-import { updateElectronApp } from 'update-electron-app'
+import { updateElectronApp, UpdateSourceType } from 'update-electron-app'
 import log from 'electron-log'
 
 log.initialize();
@@ -46,7 +46,13 @@ if (!gotLock) {
     await application.init();
     createWindow();
 
-    updateElectronApp();
+    updateElectronApp({
+      updateSource: {
+        type: UpdateSourceType.ElectronPublicUpdateService,
+        repo: 'hatappi/gomodoro-desktop',
+      },
+      logger: log,
+    });
   });
 }
 


### PR DESCRIPTION
## WHAT
Enhanced the electron updater configuration by explicitly setting the update source repository and enabling logging.

## WHY
The previous implementation used the default `updateElectronApp()` configuration which could lead to:
- Unclear update source configuration
- Limited visibility into update process and potential issues
- Less control over update behavior

This change provides:
- Explicit configuration of the update source as `ElectronPublicUpdateService` with the correct repository (`hatappi/gomodoro-desktop`)
- Integration with `electron-log` for better tracking and debugging of the update process
- More reliable and transparent auto-update functionality

The configuration ensures that the app will check for updates from the correct GitHub repository and log update events for better monitoring and troubleshooting.