### PR TITLE
Fix gomodoro CLI path to use absolute path

### DIFF
--- a/src/main/app/Application.ts
+++ b/src/main/app/Application.ts
@@ -23,7 +23,7 @@ export default class Application {
     const ok = await this.gql.testReconnect(2);
     if (!ok) {
       try {
-        this.gomodoroCLIProcess = spawn('gomodoro', ['serve'], {
+        this.gomodoroCLIProcess = spawn('/usr/local/bin/gomodoro', ['serve'], {
           detached: false,
           stdio: 'pipe'
         });


### PR DESCRIPTION
## WHAT
Updated the gomodoro CLI spawn command in Application.ts to use the absolute path `/usr/local/bin/gomodoro` instead of relying on PATH lookup.

## WHY
This ensures the gomodoro CLI is found correctly when spawning the server process, preventing potential issues where the binary might not be found in the PATH environment variable.

The change improves reliability by using an explicit path to the gomodoro executable.