### PR TITLE
Refactor GraphQL service management to reduce instance creation

### DIFF
--- a/src/main/app/Application.ts
+++ b/src/main/app/Application.ts
@@ -15,8 +15,7 @@ export default class Application {
 
   public async init(): Promise<void> {
     log.info('[Application] init');
-    registerIpcHandlers();
-
+    
     // Initialize GraphQL service and run a connection check
     this.gql = new GraphQLService({ httpUrl: GRAPHQL_HTTP_URL, wsUrl: GRAPHQL_WS_URL });
 
@@ -48,6 +47,8 @@ export default class Application {
     const notificationService = new NotificationService();
     this.trayManager = new TrayManager(this.pomodoroService, undefined, notificationService);
     this.trayManager.init();
+    
+    registerIpcHandlers(this.gql);
   }
 
   public async destroy(): Promise<void> {

--- a/src/main/services/GraphQLService.ts
+++ b/src/main/services/GraphQLService.ts
@@ -78,7 +78,15 @@ export class GraphQLService {
       httpLink,
     );
 
-    return new ApolloClient({ link, cache: new InMemoryCache(), connectToDevTools: false });
+    return new ApolloClient({
+      link,
+      cache: new InMemoryCache(),
+      connectToDevTools: false,
+      defaultOptions: {
+        query: { fetchPolicy: 'no-cache' },
+        watchQuery: { fetchPolicy: 'no-cache' }
+      }
+    });
   }
 
   public async query<TData, TVariables extends Record<string, unknown> = Record<string, unknown>>(


### PR DESCRIPTION
## WHAT
- Move IPC handler registration after GraphQL service initialization in Application.ts
- Pass shared GraphQL service instance to IPC handlers instead of creating multiple instances
- Add `fetchPolicy: 'no-cache'` to Apollo Client configuration to prevent caching issues
- Create single PomodoroService instance in IPC handlers for better resource management

## WHY
This refactoring improves the application architecture by:

1. **Reducing resource overhead**: Previously, each IPC handler was creating its own GraphQL service and PomodoroService instances, leading to unnecessary resource usage and potential connection issues.

2. **Ensuring consistent service state**: By passing a shared GraphQL service instance, we ensure all handlers use the same connection and configuration.

3. **Preventing caching issues**: The `fetchPolicy: 'no-cache'` configuration ensures fresh data is always fetched, which is important for real-time pomodoro state management.

4. **Improving initialization order**: Moving IPC handler registration after GraphQL service initialization ensures handlers have access to a properly configured service instance.

This change maintains the same functionality while improving performance and reliability.