### PR TITLE
Remove automatic dev tools opening in production

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -24,8 +24,6 @@ const createWindow = () => {
   } else {
     mainWindow.loadFile(path.join(__dirname, `../renderer/${MAIN_WINDOW_VITE_NAME}/index.html`));
   }
-
-  mainWindow.webContents.openDevTools();
 };
 
 const gotLock = app.requestSingleInstanceLock();


### PR DESCRIPTION
## WHAT
- Removed `mainWindow.webContents.openDevTools()` from `src/main/main.ts`
- This prevents developer tools from automatically opening when the application starts

## WHY
- The automatic opening of developer tools was intended for development but was left in production code
- End users should not see developer tools when using the application
- This improves the user experience by providing a cleaner interface without debug tools
- Maintains the professional appearance of the packaged desktop application

🤖 Generated with [Claude Code](https://claude.ai/code)