### PR TITLE
Remove unused ping IPC functionality

### DIFF
--- a/src/main/ipc/channels.ts
+++ b/src/main/ipc/channels.ts
@@ -1,5 +1,4 @@
 export const IPC_CHANNELS = {
-  PING: 'app:ping',
   GET_CONFIG: 'app:get-config',
   CHECK_GRAPHQL_CONNECTION: 'app:check-graphql-connection',
   GET_CURRENT_POMODORO: 'pomodoro:get-current',

--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -35,11 +35,6 @@ async function withIpcErrorHandling<T>(handler: () => Promise<T>): Promise<IpcRe
 }
 
 export function registerIpcHandlers(gql: GraphQLService): void {
-  // Simple ping handler to validate the wiring end-to-end
-  ipcMain.handle(IPC_CHANNELS.PING, async (_event, message?: string) => {
-    return withIpcErrorHandling(async () => `pong:${message ?? ''}`);
-  });
-
   // Example config retrieval (placeholder)
   ipcMain.handle(IPC_CHANNELS.GET_CONFIG, async () => {
     return withIpcErrorHandling(async () => ({

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -19,11 +19,6 @@ async function invokeIpc<T>(channel: string, ...args: any[]): Promise<T> {
 
 // Expose a minimal, typed API to the renderer (secure bridge)
 const api = {
-  // Simple health check; this can be expanded to IPC later
-  ping: async (message?: string) => {
-    const result = await invokeIpc<string>(IPC_CHANNELS.PING, message ?? '');
-    return String(result);
-  },
   getConfig: () => invokeIpc<{ env: string }>(IPC_CHANNELS.GET_CONFIG),
   checkGraphQLConnection: () => invokeIpc<{ isConnected: boolean }>(IPC_CHANNELS.CHECK_GRAPHQL_CONNECTION),
   getCurrentPomodoro: () => invokeIpc<Pomodoro | null>(IPC_CHANNELS.GET_CURRENT_POMODORO),

--- a/src/shared/types/electron.ts
+++ b/src/shared/types/electron.ts
@@ -11,7 +11,6 @@ export type IpcResponse<T = unknown> = {
 };
 
 export interface ElectronAPI {
-  ping: (message?: string) => Promise<string>;
   getConfig: () => Promise<{ env: string }>;
   checkGraphQLConnection: () => Promise<{ isConnected: boolean }>;
   getCurrentPomodoro: () => Promise<Pomodoro | null>;


### PR DESCRIPTION
## WHAT
<\!-- Describe what changes you made -->
Removed the unused ping IPC functionality from the Electron application, including:
- Removed `PING` channel from `IPC_CHANNELS`
- Removed ping handler from `registerIpcHandlers`
- Removed ping method from preload API
- Removed ping method from `ElectronAPI` interface

## WHY
<\!-- Explain why these changes were necessary -->
The ping functionality was originally added for testing IPC connectivity but is no longer needed. Removing this dead code helps keep the IPC layer clean and reduces the API surface area.

Changes made to:
- `src/main/ipc/channels.ts`
- `src/main/ipc/handlers.ts` 
- `src/preload/preload.ts`
- `src/shared/types/electron.ts`