### PR TITLE
Fix ESLint warnings and improve type safety

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,5 +12,6 @@
     "plugin:import/electron",
     "plugin:import/typescript"
   ],
-  "parser": "@typescript-eslint/parser"
+  "parser": "@typescript-eslint/parser",
+  "ignorePatterns": ["src/shared/graphql/generated.ts"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gomodoro-desktop",
-  "version": "0.0.11",
+  "version": "0.0.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gomodoro-desktop",
-      "version": "0.0.11",
+      "version": "0.0.15",
       "license": "MIT",
       "dependencies": {
         "@apollo/client": "^3.10.8",
@@ -35,7 +35,7 @@
         "@types/react": "^19.1.9",
         "@types/react-dom": "^19.1.7",
         "@typescript-eslint/eslint-plugin": "^5.62.0",
-        "@typescript-eslint/parser": "^5.62.0",
+        "@typescript-eslint/parser": "^8.42.0",
         "@vitejs/plugin-react": "^4.3.4",
         "electron": "37.2.4",
         "eslint": "^8.57.1",
@@ -4802,31 +4802,182 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "5.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz",
-      "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
+      "version": "8.42.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.42.0.tgz",
+      "integrity": "sha512-r1XG74QgShUgXph1BYseJ+KZd17bKQib/yF3SR+demvytiRXrwd12Blnz5eYGm8tXaeRdd4x88MlfwldHoudGg==",
       "dev": true,
-      "license": "BSD-2-Clause",
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.62.0",
-        "@typescript-eslint/types": "5.62.0",
-        "@typescript-eslint/typescript-estree": "5.62.0",
+        "@typescript-eslint/scope-manager": "8.42.0",
+        "@typescript-eslint/types": "8.42.0",
+        "@typescript-eslint/typescript-estree": "8.42.0",
+        "@typescript-eslint/visitor-keys": "8.42.0",
         "debug": "^4.3.4"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.42.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.42.0.tgz",
+      "integrity": "sha512-51+x9o78NBAVgQzOPd17DkNTnIzJ8T/O2dmMBLoK9qbY0Gm52XJcdJcCl18ExBMiHo6jPMErUQWUv5RLE51zJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.42.0",
+        "@typescript-eslint/visitor-keys": "8.42.0"
       },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/types": {
+      "version": "8.42.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.42.0.tgz",
+      "integrity": "sha512-LdtAWMiFmbRLNP7JNeY0SqEtJvGMYSzfiWBSmx+VSZ1CH+1zyl8Mmw1TT39OrtsRvIYShjJWzTDMPWZJCpwBlw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.42.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.42.0.tgz",
+      "integrity": "sha512-ku/uYtT4QXY8sl9EDJETD27o3Ewdi72hcXg1ah/kkUgBvAYHLwj2ofswFFNXS+FL5G+AGkxBtvGt8pFBHKlHsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.42.0",
+        "@typescript-eslint/tsconfig-utils": "8.42.0",
+        "@typescript-eslint/types": "8.42.0",
+        "@typescript-eslint/visitor-keys": "8.42.0",
+        "debug": "^4.3.4",
+        "fast-glob": "^3.3.2",
+        "is-glob": "^4.0.3",
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^2.1.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.42.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.42.0.tgz",
+      "integrity": "sha512-3WbiuzoEowaEn8RSnhJBrxSwX8ULYE9CXaPepS2C2W3NSA5NNIvBaslpBSBElPq0UGr0xVJlXFWOAKIkyylydQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.42.0",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.42.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.42.0.tgz",
+      "integrity": "sha512-vfVpLHAhbPjilrabtOSNcUDmBboQNrJUiNAGoImkZKnMjs2TIcWG33s4Ds0wY3/50aZmTMqJa6PiwkwezaAklg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.42.0",
+        "@typescript-eslint/types": "^8.42.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service/node_modules/@typescript-eslint/types": {
+      "version": "8.42.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.42.0.tgz",
+      "integrity": "sha512-LdtAWMiFmbRLNP7JNeY0SqEtJvGMYSzfiWBSmx+VSZ1CH+1zyl8Mmw1TT39OrtsRvIYShjJWzTDMPWZJCpwBlw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
@@ -4845,6 +4996,23 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.42.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.42.0.tgz",
+      "integrity": "sha512-kHeFUOdwAJfUmYKjR3CLgZSglGHjbNTi1H8sTYRYV2xX6eNz4RyJ2LIgsDLKf8Yi0/GL1WZAC/DgZBeBft8QAQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
@@ -12861,6 +13029,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
+      "integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
       }
     },
     "node_modules/ts-invariant": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@types/react": "^19.1.9",
     "@types/react-dom": "^19.1.7",
     "@typescript-eslint/eslint-plugin": "^5.62.0",
-    "@typescript-eslint/parser": "^5.62.0",
+    "@typescript-eslint/parser": "^8.42.0",
     "@vitejs/plugin-react": "^4.3.4",
     "electron": "37.2.4",
     "eslint": "^8.57.1",

--- a/src/main/app/TrayManager.ts
+++ b/src/main/app/TrayManager.ts
@@ -1,9 +1,7 @@
 import { app, BrowserWindow, Menu, MenuItemConstructorOptions, Tray, nativeImage } from 'electron';
 import PomodoroService from '../services/PomodoroService';
 import NotificationService from '../services/NotificationService';
-import type { Pomodoro } from '../../shared/types/gomodoro';
-import type { PomodoroState } from '../../shared/types/gomodoro';
-import type { PomodoroPhase } from '../../shared/types/gomodoro';
+import type { Pomodoro, PomodoroState, PomodoroPhase } from '../../shared/types/gomodoro';
 import { ERROR_MESSAGES } from '../../shared/constants/errorMessages';
 import log from 'electron-log/main'
 

--- a/src/main/services/GraphQLService.ts
+++ b/src/main/services/GraphQLService.ts
@@ -56,7 +56,7 @@ export class GraphQLService {
   private createApolloClient(): ApolloClient<NormalizedCacheObject> {
     const httpLink = new HttpLink({
       uri: this.httpUrl,
-      fetch: (globalThis as any).fetch,
+      fetch: globalThis.fetch,
       headers: this.authToken ? { Authorization: `Bearer ${this.authToken}` } : undefined,
     });
 
@@ -93,7 +93,7 @@ export class GraphQLService {
     document: TypedDocumentNode<TData, TVariables>,
     variables?: TVariables,
   ): Promise<TData> {
-    const res = await this.apollo.query({ query: document, variables: variables as any });
+    const res = await this.apollo.query({ query: document, variables });
     return res.data;
   }
 
@@ -101,7 +101,7 @@ export class GraphQLService {
     document: TypedDocumentNode<TData, TVariables>,
     variables?: TVariables,
   ): Promise<TData> {
-    const res = await this.apollo.mutate({ mutation: document, variables: variables as any });
+    const res = await this.apollo.mutate({ mutation: document, variables });
     if (!res.data) throw new Error('Empty mutation response');
     return res.data;
   }
@@ -112,7 +112,7 @@ export class GraphQLService {
     next: (data: TData) => void,
     error?: (err: unknown) => void,
   ): () => void {
-    const sub = this.apollo.subscribe({ query: document, variables: variables as any }).subscribe({
+    const sub = this.apollo.subscribe({ query: document, variables }).subscribe({
       next: (payload) => next(payload.data as TData),
       error: (err) => error?.(err),
     });

--- a/src/main/services/PomodoroService.ts
+++ b/src/main/services/PomodoroService.ts
@@ -125,20 +125,28 @@ export default class PomodoroService {
       OnPomodoroEventDocument,
       variables,
       (data) => {
-        const payload = data.eventReceived?.payload as unknown;
-        if (payload && typeof payload === 'object' && 'remainingTimeSec' in payload) {
-          const p = payload as { id: string; state: Pomodoro['state']; taskId?: string | null; phase: Pomodoro['phase']; phaseCount: number; phaseDurationSec: number; remainingTimeSec: number; elapsedTimeSec: number };
-          onEvent({
-            id: p.id,
-            state: p.state,
-            taskId: p.taskId ?? '',
-            phase: p.phase,
-            phaseCount: p.phaseCount,
-            phaseDurationSec: p.phaseDurationSec,
-            remainingTimeSec: p.remainingTimeSec,
-            elapsedTimeSec: p.elapsedTimeSec,
-          });
+        const payload = data.eventReceived?.payload;
+        if (!payload) {
+          onError?.('Failed to get payload. payload not found.');
+          return;
         }
+
+        if (payload.__typename !== 'EventPomodoroPayload') {
+          onError?.('Failed to get payload. payload is not a pomodoro event.');
+          return;
+        }
+
+        const p = payload as { id: string; state: Pomodoro['state']; taskId?: string | null; phase: Pomodoro['phase']; phaseCount: number; phaseDurationSec: number; remainingTimeSec: number; elapsedTimeSec: number };
+        onEvent({
+          id: p.id,
+          state: p.state,
+          taskId: p.taskId ?? '',
+          phase: p.phase,
+          phaseCount: p.phaseCount,
+          phaseDurationSec: p.phaseDurationSec,
+          remainingTimeSec: p.remainingTimeSec,
+          elapsedTimeSec: p.elapsedTimeSec,
+        });
       },
       onError,
     );

--- a/src/main/services/PomodoroService.ts
+++ b/src/main/services/PomodoroService.ts
@@ -27,6 +27,7 @@ import {
   DeleteTaskDocument,
   type DeleteTaskMutation,
   type DeleteTaskMutationVariables,
+  EventCategory,
 } from '../../shared/graphql/generated';
 import type { Pomodoro, StartPomodoroParams, Task } from '../../shared/types/gomodoro';
 
@@ -52,7 +53,9 @@ export default class PomodoroService {
 
   public async startPomodoro(input: StartPomodoroParams): Promise<Pomodoro> {
     const data = await this.gql.mutate<StartPomodoroMutation, StartPomodoroMutationVariables>(StartPomodoroDocument, { input });
-    const p = data.startPomodoro!;
+    const p = data.startPomodoro;
+    if (!p) throw new Error('Failed to start pomodoro. started pomodoro not found.');
+
     return {
       id: p.id,
       state: p.state,
@@ -67,7 +70,8 @@ export default class PomodoroService {
 
   public async pausePomodoro(): Promise<Pomodoro> {
     const data = await this.gql.mutate<PausePomodoroMutation, Record<string, never>>(PausePomodoroDocument, {} as Record<string, never>);
-    const p = data.pausePomodoro!;
+    const p = data.pausePomodoro;
+    if (!p) throw new Error('Failed to pause pomodoro. paused pomodoro not found.');
     return {
       id: p.id,
       state: p.state,
@@ -82,7 +86,8 @@ export default class PomodoroService {
 
   public async resumePomodoro(): Promise<Pomodoro> {
     const data = await this.gql.mutate<ResumePomodoroMutation, Record<string, never>>(ResumePomodoroDocument, {} as Record<string, never>);
-    const p = data.resumePomodoro!;
+    const p = data.resumePomodoro;
+    if (!p) throw new Error('Failed to resume pomodoro. resumed pomodoro not found.');
     return {
       id: p.id,
       state: p.state,
@@ -97,7 +102,8 @@ export default class PomodoroService {
 
   public async stopPomodoro(): Promise<Pomodoro> {
     const data = await this.gql.mutate<StopPomodoroMutation, Record<string, never>>(StopPomodoroDocument, {} as Record<string, never>);
-    const p = data.stopPomodoro!;
+    const p = data.stopPomodoro;
+    if (!p) throw new Error('Failed to stop pomodoro. stopped pomodoro not found.');
     return {
       id: p.id,
       state: p.state,
@@ -114,13 +120,13 @@ export default class PomodoroService {
     onEvent: (p: Pomodoro) => void,
     onError?: (err: unknown) => void,
   ): () => void {
-    const variables: OnPomodoroEventSubscriptionVariables = { input: { eventCategory: ['POMODORO' as any] } };
+    const variables: OnPomodoroEventSubscriptionVariables = { input: { eventCategory: [EventCategory.Pomodoro] } };
     return this.gql.subscribe<OnPomodoroEventSubscription, OnPomodoroEventSubscriptionVariables>(
       OnPomodoroEventDocument,
       variables,
       (data) => {
-        const payload = data.eventReceived?.payload as any;
-        if (payload && 'remainingTimeSec' in payload) {
+        const payload = data.eventReceived?.payload as unknown;
+        if (payload && typeof payload === 'object' && 'remainingTimeSec' in payload) {
           const p = payload as { id: string; state: Pomodoro['state']; taskId?: string | null; phase: Pomodoro['phase']; phaseCount: number; phaseDurationSec: number; remainingTimeSec: number; elapsedTimeSec: number };
           onEvent({
             id: p.id,
@@ -157,7 +163,8 @@ export default class PomodoroService {
     const data = await this.gql.mutate<CreateTaskMutation, CreateTaskMutationVariables>(CreateTaskDocument, {
       input: { title: input.title }
     });
-    const task = data.createTask!;
+    const task = data.createTask;
+    if (!task) throw new Error('Failed to create task. created task not found.');
     return {
       id: task.id,
       title: task.title,
@@ -169,7 +176,8 @@ export default class PomodoroService {
     const data = await this.gql.mutate<UpdateTaskMutation, UpdateTaskMutationVariables>(UpdateTaskDocument, {
       input: { id: input.id, title: input.title }
     });
-    const task = data.updateTask!;
+    const task = data.updateTask;
+    if (!task) throw new Error('Failed to update task. updated task not found.');
     return {
       id: task.id,
       title: task.title,
@@ -183,7 +191,6 @@ export default class PomodoroService {
     });
     return data.deleteTask || false;
   }
-
 }
 
 

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -12,7 +12,7 @@ function handleIpcResponse<T>(response: IpcResponse<T>): T {
   return response.data as T;
 }
 
-async function invokeIpc<T>(channel: string, ...args: any[]): Promise<T> {
+async function invokeIpc<T>(channel: string, ...args: unknown[]): Promise<T> {
   const res = await ipcRenderer.invoke(channel, ...args);
   return handleIpcResponse<T>(res);
 }

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -48,7 +48,8 @@ export default function App(): React.ReactElement {
   const isFinished = !!pomodoro && pomodoro.state === 'FINISHED';
   
   const handleStart = () => {
-    start(selectedTaskId!);
+    if (!selectedTaskId) return;
+    start(selectedTaskId);
     setShowTaskManager(false);
   };
   

--- a/vite.renderer.config.ts
+++ b/vite.renderer.config.ts
@@ -1,6 +1,5 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
-import path from 'path';
 
 export default defineConfig({
   plugins: [react()],


### PR DESCRIPTION
## WHAT
- Add `ignorePatterns` to .eslintrc.json to exclude auto-generated GraphQL files
- Remove explicit `any` types in favor of proper TypeScript types
- Replace non-null assertions with proper null checks and error handling
- Consolidate duplicate imports in TrayManager.ts
- Remove unused path import in vite.renderer.config.ts
- Update @typescript-eslint/parser to resolve compatibility issues
- Improve payload validation in PomodoroService subscription with proper type checking

## WHY
- The codebase had 18 ESLint warnings that needed to be resolved
- Auto-generated GraphQL files should not be linted as they are machine-generated
- Using `any` types and non-null assertions reduces type safety and can lead to runtime errors
- Proper error handling and validation improves application reliability
- Clean linting helps maintain code quality standards