### PR TITLE
Add keyboard shortcuts for timer controls

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -21,7 +21,7 @@ export default function App(): React.ReactElement {
     deleteTask
   } = useTasks();
   
-  const [showTaskManager, setShowTaskManager] = useState(false);
+  const [showTaskManager, setShowTaskManager] = useState(true);
   const isInitializedRef = useRef(false);
  
   // Initialize selectedTaskId and showTaskManager
@@ -34,9 +34,8 @@ export default function App(): React.ReactElement {
     const initialTaskId = pomodoro?.taskId;
     if (initialTaskId && pomodoro?.state !== 'FINISHED') {
       selectTask(initialTaskId);
-    }
-
-    if (!pomodoro || !initialTaskId) {
+      setShowTaskManager(false);
+    } else {
       setShowTaskManager(true);
     } 
   }, [isLoading, tasksLoading, pomodoro, selectedTaskId, selectTask]);

--- a/src/renderer/components/Controls/Controls.tsx
+++ b/src/renderer/components/Controls/Controls.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { 
   Button, 
   Stack, 
@@ -41,6 +41,7 @@ type Props = {
 
 export default function Controls(props: Props): React.ReactElement {
   const { isLoading, canStart, canPause, canResume, canStop, isFinished, onStart, onPause, onResume, onStop, onChangeTask } = props;
+  const controlsRef = useRef<HTMLDivElement>(null);
 
   // Main action button (Start/Pause/Resume)
   const primaryAction: ControlAction | null = (() => {
@@ -74,8 +75,67 @@ export default function Controls(props: Props): React.ReactElement {
     return null;
   })();
 
+  // Keyboard shortcuts
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      // Disable shortcuts when loading
+      if (isLoading) {
+        return;
+      }
+
+      switch (event.key) {
+        case 'e': {
+          event.preventDefault();
+          if (canStop) {
+            onStop();
+          }
+          break;
+        }
+        case 'c': {
+          event.preventDefault();
+          if (isFinished) {
+            onChangeTask();
+          }
+          break;
+        }
+        case 'Enter': {
+          event.preventDefault();
+          if (canStart) {
+            onStart();
+          } else if (canPause) {
+            onPause();
+          } else if (canResume) {
+            onResume();
+          }
+          break;
+        }
+      }
+    };
+
+    const ref = controlsRef.current;
+    if (ref) {
+      ref.addEventListener('keydown', handleKeyDown);
+      return () => {
+        ref.removeEventListener('keydown', handleKeyDown);
+      };
+    }
+  }, [isLoading, canStart, canPause, canResume, canStop, isFinished, onStart, onPause, onResume, onStop, onChangeTask]);
+
+  useEffect(() => {
+    // To enable keyboard shortcuts when component becomes visible
+    controlsRef.current?.focus();
+  }, []);
+
   return (
-    <Box>
+    <Box
+      ref={controlsRef}
+      tabIndex={0}
+      sx={{
+        '&:focus-visible': {
+          outline: 'none',
+        }
+      }}
+    >
       {isLoading && (
         <Chip
           icon={<CircularProgress size='clamp(12px, 2vw, 20px)' />}


### PR DESCRIPTION
## WHAT
- Added keyboard shortcuts to the timer controls interface:
  - `e` key: Stop timer
  - `c` key: Change task (available when timer is finished)
  - `Enter` key: Context-aware primary action (start/pause/resume timer)
- Fixed initial screen display to properly show task manager on first launch
- Implemented focus management for immediate keyboard shortcut availability

## WHY
- Improves user experience by providing keyboard navigation for timer controls
- Maintains consistency with existing TaskManager keyboard shortcuts
- Enables faster workflow for power users who prefer keyboard navigation
- Addresses issue where timer screen was incorrectly displayed on initial launch

The implementation follows the existing keyboard shortcut patterns established in TaskManager.tsx, ensuring a consistent user experience throughout the application.

🤖 Generated with [Claude Code](https://claude.ai/code)