### PR TITLE
Add keyboard shortcuts for tray menu operations

### DIFF
--- a/src/main/app/Application.ts
+++ b/src/main/app/Application.ts
@@ -5,6 +5,7 @@ import PomodoroService from '../services/PomodoroService';
 import TrayManager from './TrayManager';
 import NotificationService from '../services/NotificationService';
 import { spawn, ChildProcess } from 'child_process';
+import { globalShortcut } from 'electron';
 import log from 'electron-log/main'
 
 export default class Application {
@@ -48,10 +49,13 @@ export default class Application {
     this.trayManager = new TrayManager(this.pomodoroService, undefined, notificationService);
     this.trayManager.init();
     
+    this.registerGlobalShortcuts();
+    
     registerIpcHandlers(this.gql);
   }
 
   public async destroy(): Promise<void> {
+    globalShortcut.unregisterAll();
     this.trayManager?.destroy();
     
     if (this.gomodoroCLIProcess) {
@@ -64,6 +68,14 @@ export default class Application {
       }
     }
   }
+
+  private registerGlobalShortcuts(): void {
+    const ret = globalShortcut.register('CommandOrControl+Ctrl+G', () => {
+      this.trayManager?.showTrayMenu();
+    });
+
+    if (!ret) {
+      log.error('[Application] Failed to register global shortcut');
+    }
+  }
 }
-
-

--- a/src/main/app/TrayManager.ts
+++ b/src/main/app/TrayManager.ts
@@ -84,6 +84,7 @@ export default class TrayManager {
     const template: MenuItemConstructorOptions[] = [
       {
         label: 'Show / Hide',
+        accelerator: 't',
         click: () => this.toggleMainWindow(),
       },
     ];
@@ -92,6 +93,7 @@ export default class TrayManager {
     if (canStart) {
       actionItems.push({
         label: 'Start',
+        accelerator: 's',
         click: async () => {
           try {
             await this.pomodoroService.startPomodoro(this.config);
@@ -104,6 +106,7 @@ export default class TrayManager {
     if (canPause) {
       actionItems.push({
         label: 'Pause',
+        accelerator: 'p',
         click: () => this.pomodoroService.pausePomodoro().catch((error) => {
           log.error('[TrayManager] Failed to pause pomodoro:', error);
         }),
@@ -112,6 +115,7 @@ export default class TrayManager {
     if (canResume) {
       actionItems.push({
         label: 'Resume',
+        accelerator: 'r',
         click: () => this.pomodoroService.resumePomodoro().catch((error) => {
           log.error('[TrayManager] Failed to resume pomodoro:', error);
         }),
@@ -120,6 +124,7 @@ export default class TrayManager {
     if (canStop) {
       actionItems.push({
         label: 'Stop',
+        accelerator: 'x',
         click: () => this.pomodoroService.stopPomodoro().catch((error) => {
           log.error('[TrayManager] Failed to stop pomodoro:', error);
         }),
@@ -135,7 +140,7 @@ export default class TrayManager {
       {
         label: 'Quit',
         role: 'quit',
-        accelerator: 'Cmd+Q',
+        accelerator: 'q',
         click: () => app.quit(),
       },
     );
@@ -163,6 +168,15 @@ export default class TrayManager {
       win.focus();
     }
   }
+
+  public showTrayMenu(): void {
+    if (!this.tray) {
+      return;
+    }
+    
+    this.tray.popUpContextMenu();
+  }
+
 
   private setTrayTitle(text: string): void {
     if (!this.tray) return;


### PR DESCRIPTION
## WHAT
Added keyboard shortcuts for tray menu operations to improve user experience and accessibility:

- **Global shortcut**: `Cmd+Ctrl+G` to open the tray menu from anywhere
- **Tray menu accelerators**: Single-key shortcuts when menu is open:
  - `t` for Show/Hide main window
  - `s` for Start pomodoro
  - `p` for Pause pomodoro  
  - `r` for Resume pomodoro
  - `x` for Stop pomodoro
  - `q` for Quit application (simplified from `Cmd+Q`)

## WHY
This enhancement provides:
1. **Quick access**: Users can open tray menu with a global shortcut without needing to click the tray icon
2. **Keyboard-driven workflow**: Consistent with existing UI components (Controls.tsx, TaskManager.tsx) that use single-key shortcuts
3. **Better accessibility**: Keyboard navigation improves usability for power users
4. **Unified UX**: Matches the single-key shortcut pattern already established in the renderer components

The implementation follows the existing patterns in the codebase and includes proper cleanup of global shortcuts on app destroy.