### PR TITLE
feat: add task manager integration to tray menu

### DIFF
--- a/src/main/ipc/channels.ts
+++ b/src/main/ipc/channels.ts
@@ -1,6 +1,7 @@
 export const IPC_CHANNELS = {
   GET_CONFIG: "app:get-config",
   CHECK_GRAPHQL_CONNECTION: "app:check-graphql-connection",
+  SHOW_TASK_MANAGER: "app:show-task-manager",
   GET_CURRENT_POMODORO: "pomodoro:get-current",
   START_POMODORO: "pomodoro:start",
   PAUSE_POMODORO: "pomodoro:pause",

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -38,6 +38,12 @@ const api = {
     return () =>
       ipcRenderer.removeListener(IPC_CHANNELS.POMODORO_EVENT, handler);
   },
+  onShowTaskManager: (listener: () => void) => {
+    const handler = () => listener();
+    ipcRenderer.on(IPC_CHANNELS.SHOW_TASK_MANAGER, handler);
+    return () =>
+      ipcRenderer.removeListener(IPC_CHANNELS.SHOW_TASK_MANAGER, handler);
+  },
 
   // Task management
   listTasks: () => invokeIpc<Task[]>(IPC_CHANNELS.LIST_TASKS),

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -57,6 +57,17 @@ export default function App(): React.ReactElement {
     }
   }, [isLoading, tasksLoading, pomodoro, selectedTaskId, selectTask]);
 
+  // Listen for show task manager event from main process
+  useEffect(() => {
+    const off = window.electronAPI.onShowTaskManager(() => {
+      setShowTaskManager(true);
+    });
+
+    return () => {
+      off();
+    };
+  }, []);
+
   const canStart =
     (!pomodoro ||
       (pomodoro.state !== "ACTIVE" && pomodoro.state !== "PAUSED")) &&

--- a/src/shared/types/electron.ts
+++ b/src/shared/types/electron.ts
@@ -22,6 +22,7 @@ export interface ElectronAPI {
   stopPomodoro: () => Promise<Pomodoro>;
   resetPomodoro: () => Promise<Pomodoro>;
   onPomodoroEvent: (listener: (event: Pomodoro) => void) => () => void;
+  onShowTaskManager: (listener: () => void) => () => void;
 
   // Task management
   listTasks: () => Promise<Task[]>;


### PR DESCRIPTION
## WHAT

Added task manager integration to the system tray menu with new "Change Task" and "Reset" options that appear when a pomodoro is finished.

Key changes:
- Added `SHOW_TASK_MANAGER` IPC channel for main-to-renderer communication
- Added "Change Task" (accelerator: `c`) and "Reset" (accelerator: `r`) menu items in TrayManager when pomodoro state is `FINISHED`
- Changed "Resume" accelerator from `r` to `u` to free up the `r` key for "Reset"
- Implemented `showTaskManagerAndWindow()` method that sends IPC event to renderer and brings window to focus
- Added `onShowTaskManager` event listener in renderer App component to open task manager dialog

## WHY

This improves the user experience by allowing users to quickly change tasks or reset the pomodoro directly from the system tray without having to manually open the application window. When a pomodoro finishes, users can immediately take action to start their next task or reset the timer - all from the convenient tray menu interface.